### PR TITLE
SwiftUIフロントエンド初期コミット

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,20 @@ backend/.venv/
 
 # macOSの隠しファイル
 .DS_Store
+
+# Xcode関連
+**/xcuserstate
+**/xcuserdata/
+
+# VCS関連（複数人開発で重要）
+*.xccheckout
+*.xcscmblueprint
+
+# Xcodeビルド関連
+frontend/build/
+frontend/DerivedData/
+
+# App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM

--- a/frontend/PeriodTracker.xcodeproj/project.pbxproj
+++ b/frontend/PeriodTracker.xcodeproj/project.pbxproj
@@ -1,0 +1,327 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		15A17A4D2E17BBD500AF60A3 /* PeriodTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PeriodTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		15A17A4F2E17BBD500AF60A3 /* PeriodTracker */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PeriodTracker;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		15A17A4A2E17BBD500AF60A3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		15A17A442E17BBD500AF60A3 = {
+			isa = PBXGroup;
+			children = (
+				15A17A4F2E17BBD500AF60A3 /* PeriodTracker */,
+				15A17A4E2E17BBD500AF60A3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		15A17A4E2E17BBD500AF60A3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				15A17A4D2E17BBD500AF60A3 /* PeriodTracker.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		15A17A4C2E17BBD500AF60A3 /* PeriodTracker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 15A17A582E17BBD600AF60A3 /* Build configuration list for PBXNativeTarget "PeriodTracker" */;
+			buildPhases = (
+				15A17A492E17BBD500AF60A3 /* Sources */,
+				15A17A4A2E17BBD500AF60A3 /* Frameworks */,
+				15A17A4B2E17BBD500AF60A3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				15A17A4F2E17BBD500AF60A3 /* PeriodTracker */,
+			);
+			name = PeriodTracker;
+			packageProductDependencies = (
+			);
+			productName = PeriodTracker;
+			productReference = 15A17A4D2E17BBD500AF60A3 /* PeriodTracker.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		15A17A452E17BBD500AF60A3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					15A17A4C2E17BBD500AF60A3 = {
+						CreatedOnToolsVersion = 16.4;
+					};
+				};
+			};
+			buildConfigurationList = 15A17A482E17BBD500AF60A3 /* Build configuration list for PBXProject "PeriodTracker" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 15A17A442E17BBD500AF60A3;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 15A17A4E2E17BBD500AF60A3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				15A17A4C2E17BBD500AF60A3 /* PeriodTracker */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		15A17A4B2E17BBD500AF60A3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		15A17A492E17BBD500AF60A3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		15A17A562E17BBD600AF60A3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		15A17A572E17BBD600AF60A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		15A17A592E17BBD600AF60A3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = name.taisukefujise.PeriodTracker;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		15A17A5A2E17BBD600AF60A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = name.taisukefujise.PeriodTracker;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		15A17A482E17BBD500AF60A3 /* Build configuration list for PBXProject "PeriodTracker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				15A17A562E17BBD600AF60A3 /* Debug */,
+				15A17A572E17BBD600AF60A3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		15A17A582E17BBD600AF60A3 /* Build configuration list for PBXNativeTarget "PeriodTracker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				15A17A592E17BBD600AF60A3 /* Debug */,
+				15A17A5A2E17BBD600AF60A3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 15A17A452E17BBD500AF60A3 /* Project object */;
+}

--- a/frontend/PeriodTracker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/frontend/PeriodTracker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/frontend/PeriodTracker/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/frontend/PeriodTracker/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/PeriodTracker/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/frontend/PeriodTracker/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/PeriodTracker/Assets.xcassets/Contents.json
+++ b/frontend/PeriodTracker/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/PeriodTracker/ContentView.swift
+++ b/frontend/PeriodTracker/ContentView.swift
@@ -1,0 +1,43 @@
+//
+//  ContentView.swift
+//  Period_demo
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State private var isLoggedIn = false
+    @State private var selectedTab = 1
+
+    var body: some View {
+        if !isLoggedIn {
+            LoginView(isLoggedIn: $isLoggedIn)
+        } else{
+        TabView(selection: $selectedTab) {
+            CalendarView()
+                .tabItem {
+                    Label("Calendar", systemImage: "calendar")
+                }
+                .tag(0)
+            
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house.fill")
+                }
+                .tag(1)
+            
+            ChatView()
+                .tabItem {
+                    Label("Chat", systemImage: "message.fill")
+                }
+                .tag(2)
+        }
+    }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/frontend/PeriodTracker/Features/Auth/LoginView.swift
+++ b/frontend/PeriodTracker/Features/Auth/LoginView.swift
@@ -1,0 +1,98 @@
+//
+//  Untitled.swift
+//  FriendsFavoriteMovies
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @Binding var isLoggedIn: Bool
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.blue.opacity(0.1)
+                    .ignoresSafeArea()
+                VStack(spacing: 16) {
+                        Image(systemName: "heart.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 50, height: 50)
+                            .foregroundColor(.blue)
+                        
+                        Text("PeriodCare")
+                            .font(.title)
+                            .fontWeight(.bold)
+                        
+                        Text("あなたの健康をサポート")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        
+                        TextField("メールアドレス", text: .constant(""))
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .padding(.horizontal)
+                        
+                        SecureField("パスワード", text: .constant(""))
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .padding(.horizontal)
+                        
+                        Button(action: {
+                            // パスワードリセット処理
+                        }) {
+                            Text("パスワードをお忘れの方はこちら")
+                                .font(.footnote)
+                                .foregroundColor(.blue)
+                        }
+                        Button(action: {
+                            isLoggedIn = true
+                        }) {
+                            Text("ログイン")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                        }
+                        .padding(.horizontal)
+                        
+                        
+                        
+                        Button(action: {
+                            // Googleログイン処理
+                        }) {
+                            Text("Google でログイン")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.gray.opacity(0.2))
+                                .foregroundColor(.black)
+                                .cornerRadius(8)
+                        }
+                        .padding(.horizontal)
+                        Divider()
+                        Text("登録がお済みでない方はこちら")
+                            .font(.caption)
+                        NavigationLink(destination: SignUpView()) {
+                            Text("新規登録")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                        }
+                        .padding(.horizontal)
+                    
+                }
+                .frame(width: UIScreen.main.bounds.width * 0.8,
+                       height: UIScreen.main.bounds.height * 0.7)
+                .background(Color.white)
+                .cornerRadius(20)
+                .shadow(radius:10)
+            }
+        }
+    }
+}
+
+#Preview {
+    LoginView(isLoggedIn: .constant(false))
+}

--- a/frontend/PeriodTracker/Features/Auth/SignUpView.swift
+++ b/frontend/PeriodTracker/Features/Auth/SignUpView.swift
@@ -1,0 +1,82 @@
+//
+//  SignUp.swift
+//  FriendsFavoriteMovies
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+
+struct SignUpView: View {
+    @State private var isAgreementChecked = false
+    var body: some View {
+        ZStack{
+            Color.blue.opacity(0.1)
+                .ignoresSafeArea()
+            VStack(spacing: 16) {
+                Image(systemName: "heart.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 50, height: 50)
+                    .foregroundColor(.blue)
+                
+                Text("PeriodCare")
+                    .font(.title)
+                    .fontWeight(.bold)
+                
+                Text("あなたの健康をサポート")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                
+                TextField("お名前", text: .constant(""))
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                
+                TextField("メールアドレス", text: .constant(""))
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                
+                SecureField("パスワード", text: .constant(""))
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                
+                SecureField("パスワード（確認）", text: .constant(""))
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                
+                Button(action: {
+                    isAgreementChecked.toggle()
+                }) {
+                    HStack(alignment: .top) {
+                        Image(systemName: isAgreementChecked ? "checkmark.square" : "square")
+                            .padding(.top, 2)
+                        Text(.init("[利用規約](https://example.com/terms)及び[プライバシーポリシー](https://example.com/privacy)に同意してアカウントを作成します。"))
+                            .font(.footnote)
+                            .foregroundColor(.primary)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                .padding()
+                
+                Button(action: {
+                    // 登録処理
+                }) {
+                    Text("新規登録")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+            .padding()
+            .frame(width: UIScreen.main.bounds.width * 0.8,
+                   height: UIScreen.main.bounds.height * 0.7)
+            .background(Color.white)
+            .cornerRadius(20)
+            .shadow(radius:10)
+            
+        }
+        
+    }
+}
+
+#Preview {
+    SignUpView()
+}

--- a/frontend/PeriodTracker/Features/Calendar/CalendarView.swift
+++ b/frontend/PeriodTracker/Features/Calendar/CalendarView.swift
@@ -1,0 +1,135 @@
+//
+//  CalendarView.swift
+//  FriendsFavoriteMovies
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+
+import SwiftUI
+
+struct CalendarView: View {
+    private let calendar = Calendar.current
+    private let days = ["日", "月", "火", "水", "木", "金", "土"]
+
+    @State private var selectedDate = Date()
+
+    private var monthDates: [Date] {
+        guard let monthInterval = calendar.dateInterval(of: .month, for: selectedDate) else { return [] }
+        var dates = [Date]()
+        let start = calendar.date(from: calendar.dateComponents([.year, .month], from: selectedDate))!
+        for offset in 0..<35 {
+            if let date = calendar.date(byAdding: .day, value: offset - calendar.component(.weekday, from: start) + 1, to: start) {
+                dates.append(date)
+            }
+        }
+        return dates
+    }
+
+    private var headerTitle: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy年 M月"
+        return formatter.string(from: selectedDate)
+    }
+
+    var body: some View {
+        VStack {
+            Text("周期カレンダー")
+                .font(.title)
+                .bold()
+                .frame(maxWidth: 350,alignment: .leading)
+            // Month and Year Header with Controls
+            HStack {
+                Button(action: {
+                    if let newDate = calendar.date(byAdding: .month, value: -1, to: selectedDate) {
+                        selectedDate = newDate
+                    }
+                }) {
+                    Image(systemName: "chevron.left")
+                }
+                Spacer()
+                Text(headerTitle)
+                    .font(.title2)
+                    .bold()
+                Spacer()
+                Button(action: {
+                    if let newDate = calendar.date(byAdding: .month, value: 1, to: selectedDate) {
+                        selectedDate = newDate
+                    }
+                }) {
+                    Image(systemName: "chevron.right")
+                }
+            }
+            .padding()
+            .padding(.horizontal)
+
+            // Top: Calendar Grid
+            VStack {
+                LazyVGrid(columns: Array(repeating: .init(.flexible()), count: 7), spacing: 8) {
+                    ForEach(days, id: \.self) { day in
+                        Text(day)
+                            .font(.caption)
+                            .frame(maxWidth: .infinity)
+                    }
+
+                    ForEach(monthDates, id: \.self) { date in
+                        let isToday = calendar.isDateInToday(date)
+                        let day = calendar.component(.day, from: date)
+                        Text("\(day)")
+                            .frame(maxWidth: .infinity, minHeight: 40)
+                            .background(isToday ? Color.blue : Color.clear)
+                            .foregroundColor(isToday ? .white : .primary)
+                            .clipShape(Circle())
+                    }
+                }
+                .padding()
+            }
+            .padding(.bottom)
+            .padding(.horizontal)
+
+            // Bottom: Summary Card
+            VStack(alignment: .leading, spacing: 16) {
+                Text("月間サマリー")
+                    .font(.title)
+                    .bold()
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("生理期間")
+                            .font(.title3)
+                        Text("5日")
+                            .font(.title)
+                    }
+                    .padding()
+                    .frame(maxWidth: 150, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.red.opacity(0.2))
+                    )
+
+                    VStack(alignment: .leading) {
+                        Text("平均周期")
+                            .font(.title3)
+                        Text("28日")
+                            .font(.title)
+                    }
+                    .padding()
+                    .frame(maxWidth: 150, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.blue.opacity(0.2))
+                    )
+                }
+            }
+            .padding()
+            .frame(maxWidth: 350, maxHeight: 200)
+            .background(Color(UIColor.secondarySystemBackground))
+            .cornerRadius(12)
+            .padding(.top, 0)
+        }
+        .ignoresSafeArea(edges: .top)
+    }
+}
+
+#Preview {
+    CalendarView()
+}

--- a/frontend/PeriodTracker/Features/Chat/ChatView.swift
+++ b/frontend/PeriodTracker/Features/Chat/ChatView.swift
@@ -1,0 +1,125 @@
+//
+//  ChatView.swift
+//  FriendsFavoriteMovies
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+
+struct ChatMessage: Identifiable {
+    let id: UUID = UUID()
+    let text: String
+    let isUser: Bool
+}
+
+struct ChatView: View {
+    @State private var messages: [ChatMessage] = []
+    @State private var inputText: String = ""
+    var body: some View {
+        VStack (spacing: 0){
+            HStack(spacing: 10) {
+                Image(systemName: "message.circle.fill")
+                    .resizable()
+                    .frame(width: 30, height: 30)
+                    .foregroundColor(.blue)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("相談チャット")
+                        .font(.title)
+                        .bold()
+                    Text("気軽に相談してみましょう")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+            .padding()
+            Divider()
+            ScrollViewReader { scrollProxy in
+                ScrollView{
+                    VStack(alignment: .leading, spacing: 8){
+                        ForEach(messages) { message in
+                            HStack {
+                                if message.isUser {
+                                    Spacer()
+                                    Text(message.text)
+                                        .padding()
+                                        .background(Color.green.opacity(0.3))
+                                        .cornerRadius(10)
+                                    VStack {
+                                        Image(systemName: "person.fill")
+                                            .foregroundColor(.green)
+                                        Text("ユーザー")
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                    }
+                                } else {
+                                    VStack {
+                                        Image(systemName: "bubble.left.fill")
+                                            .foregroundColor(.gray)
+                                        Text("ボット")
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    Text(message.text)
+                                        .padding()
+                                        .background(Color.gray.opacity(0.2))
+                                        .cornerRadius(10)
+                                    Spacer()
+                                }
+                            }
+                            .id(message.id)
+                        }
+                    }
+                    .padding()
+                }
+                .onChange(of: messages.count) { _ in
+                    if let last = messages.last {
+                        withAnimation {
+                            scrollProxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            
+            
+            HStack {
+                TextField("メッセージを入力...", text: $inputText)
+                    .padding(12)
+                    .background(Color(UIColor.secondarySystemBackground))
+                    .clipShape(Capsule())
+                    .font(.body)
+                    .onSubmit{
+                        sendMessage()
+                    }
+                Button(action: {
+                    sendMessage()
+                }) {
+                    Text("送信")
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(Capsule())
+                }
+            }
+            .padding()
+            .background(Color(UIColor.systemBackground))
+        }
+        .background(Color(UIColor.systemBackground))
+    }
+    
+    func sendMessage() {
+        let trimmedText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return }
+        messages.append(ChatMessage(text: trimmedText, isUser: true))
+        let response = "こんにちは、デモの応答です。"
+        messages.append(ChatMessage(text: response, isUser:false))
+        inputText = "" // Clear input field after sending
+    }
+    
+}
+
+#Preview {
+    ChatView()
+}

--- a/frontend/PeriodTracker/Features/Home/HomeView.swift
+++ b/frontend/PeriodTracker/Features/Home/HomeView.swift
@@ -1,0 +1,133 @@
+//
+//  HomeView.swift
+//  FriendsFavoriteMovies
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    @State private var showModal = true
+    @State private var selectedOption = ""
+    @State private var savedOption = ""
+    var options = ["生理周期", "月経過多", "お腹の痛み", "こめかみの痛み"]
+    
+    var body: some View {
+        ZStack{
+            if showModal {
+                Color.black.opacity(0.2)
+                    .ignoresSafeArea()
+                RecordModalView(
+                    options: options,
+                    selectedOption: $selectedOption,
+                    savedOption: $savedOption,
+                    showModal: $showModal
+                )
+            } else {
+                VStack(spacing: 24) {
+                    VStack {
+                        Text("今日の記録")
+                            .font(.largeTitle)
+                            .bold()
+                            .padding(.bottom)
+                            .frame(maxWidth: 350, alignment: .leading)
+                        
+                        HStack {
+                            ForEach(0..<6, id: \.self) { offset in
+                                let date = Calendar.current.date(byAdding: .day, value: offset - 5, to: Date())!
+                                let day = Calendar.current.component(.day, from: date)
+                                let japaneseWeekdays = ["日", "月", "火", "水", "木", "金", "土"]
+                                let weekdaySymbol = japaneseWeekdays[Calendar.current.component(.weekday, from: date) - 1]
+                                
+                                VStack {
+                                    Text(weekdaySymbol)
+                                        .font(.caption)
+                                    Text("\(day)")
+                                        .font(.caption)
+                                        .bold()
+                                }
+                                .padding()
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(offset == 5 ? Color.blue.opacity(0.8): Color.white)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .stroke(Color.gray, lineWidth: 1)
+                                )
+                                .foregroundColor(offset == 5 ? Color.white:Color.black)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                    .frame(maxWidth: 350, maxHeight: 200, alignment: .top)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.white)
+                    )
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("詳細記録")
+                            .font(.title)
+                            .bold()
+                            .padding(.bottom, 4)
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("生理周期")
+                                .font(.headline)
+                                .foregroundColor(.red)
+                            Text("次回予測: 3月28日")
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.red.opacity(0.3))
+                        )
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("体調")
+                                .font(.headline)
+                                .foregroundColor(.blue)
+                            Text("記録なし")
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.blue.opacity(0.3))
+                        )
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("症状")
+                                .font(.headline)
+                                .foregroundColor(.green)
+                            Text("記録なし")
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.green.opacity(0.3))
+                        )
+                    }
+                    .padding()
+                    .background(Color.white)
+                    .cornerRadius(16)
+                    .frame(maxWidth: 350)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(UIColor.systemBackground))
+    }
+}
+
+
+
+#Preview {
+    HomeView()
+}

--- a/frontend/PeriodTracker/Features/Home/RecordModal.swift
+++ b/frontend/PeriodTracker/Features/Home/RecordModal.swift
@@ -1,0 +1,77 @@
+//
+//  RecordModal.swift
+//  FriendsFavoriteMovies
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+import Foundation
+
+struct RecordModalView: View {
+    var options: [String]
+    @Binding var selectedOption: String
+    @Binding var savedOption: String
+    @Binding var showModal: Bool
+    
+    var body: some View {
+            VStack(spacing: 8) {
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        showModal = false
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                            .foregroundColor(.gray)
+                            .padding()
+                    }
+                }
+                .frame(height: 0)
+                VStack(spacing: 6){
+                    Text("今日の記録")
+                        .bold()
+                        .padding(.bottom, 7)
+                    Text("2025年7月4日")
+                        .font(.title)
+                        .padding(.bottom, 7)
+                        .foregroundColor(.blue) 
+                    Text("金曜日")
+                        .font(.caption)
+                        .padding(.bottom, 10)
+                    VStack(spacing: 6) {
+                        ForEach(options, id: \.self) { option in
+                            Button(action: {
+                                selectedOption = option
+                            }) {
+                                Text(option)
+                                    .frame(maxWidth: 250)
+                                    .padding(.vertical, 8)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .fill(selectedOption == option ? Color.blue.opacity(0.2) : Color.white)
+                                    )
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .stroke(Color.gray, lineWidth: 1)
+                                    )
+                            }
+                            .foregroundColor(.primary)
+                        }
+                    }
+                    .padding(.bottom, 24)
+                    
+                    Button("記録を保存する") {
+                        savedOption = selectedOption
+                        showModal = false
+                    }
+                    .padding(.bottom)
+                }
+            }
+            .frame(width: UIScreen.main.bounds.width * 0.7,
+                   height: UIScreen.main.bounds.height * 0.5)
+            .background(Color.white)
+            .cornerRadius(20)
+            .shadow(radius: 10)
+        }
+    }

--- a/frontend/PeriodTracker/PeriodTrackerApp.swift
+++ b/frontend/PeriodTracker/PeriodTrackerApp.swift
@@ -1,0 +1,17 @@
+//
+//  PeriodTrackerApp.swift
+//  PeriodTracker
+//
+//  Created by 藤瀬太翼 on 2025/07/04.
+//
+
+import SwiftUI
+
+@main
+struct PeriodTrackerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,77 @@
+## 開発環境
+
+### 必要環境
+- **Xcode**: Version 16.4 (16F6) 
+- **iOS Simulator**: iOS 18.0 以上
+- **Swift**: 6.0 以上
+
+## セットアップ手順
+
+### 1. Xcodeのインストール
+- App StoreからXcode 16.4以上をインストール
+
+### 2. プロジェクトを開く
+```bash
+# ターミナルでプロジェクトディレクトリに移動
+cd frontend
+
+# Xcodeでプロジェクトを開く
+open PeriodTracker.xcodeproj
+```
+
+### 3. ビルド・実行
+1. Xcodeでプロジェクトが開いたら、**Product → Run** を選択
+2. または **⌘ + R** でビルド・実行
+3. iOSシミュレータが起動し、アプリが表示される
+
+## 依存関係
+
+### 依存関係の管理方法
+このプロジェクトでは**Xcode内のPackage Dependencies**で依存関係を管理。
+
+#### 現在使用しているライブラリ
+- **標準ライブラリのみ使用**（外部ライブラリは追加していない）
+
+### 依存関係の追加方法
+将来的に外部ライブラリが必要になった場合：
+
+1. **Xcodeでプロジェクトを開く**
+2. **プロジェクトナビゲーターでPeriodTrackerを選択**
+3. **"Package Dependencies"タブをクリック**
+4. **"+"ボタンでパッケージを追加**
+
+### 依存関係の共有
+- **Package Dependencies**の設定は`PeriodTracker.xcodeproj`に保存される
+- **他の開発者がプロジェクトを開くと自動的に依存関係が反映される**
+- **Gitで共有可能**（`Package.resolved`ファイルも含む）
+- **全員が同じバージョンを使用**できる
+
+## プロジェクト構成
+
+```
+PeriodTracker/
+├── PeriodTrackerApp.swift      # アプリのエントリーポイント
+├── ContentView.swift           # メイン画面
+├── Features/                   # 機能別フォルダ
+│   ├── Auth/                  # 認証機能
+│   │   ├── LoginView.swift
+│   │   └── SignUpView.swift
+│   ├── Calendar/              # カレンダー機能
+│   │   └── CalendarView.swift
+│   ├── Home/                  # ホーム機能
+│   │   ├── HomeView.swift
+│   │   └── RecordModal.swift
+│   └── Chat/                  # チャット機能
+│       └── ChatView.swift
+├── Models/                    # データモデル
+│   └── Record.swift
+├── Services/                  # API通信サービス（今後実装予定）
+│   └── APIService.swift
+├── Resources/                 # モックデータ格納
+│   └── mock_records.json
+└── Assets.xcassets/           # 画像・リソース
+```
+
+アーキテクチャは機能ごとに分割した上でのMVVMパターンを採用。
+今後、それぞれの機能のフォルダにViewModelを配置する。
+型定義やAPI通信関連も未実装。


### PR DESCRIPTION
## 概要
SwiftUIフロントエンドの初期構造を追加しました。UIのみ実装で、ViewModel・API通信は未実装。.gitignoreの更新とフロントエンド開発用READMEも追加。

## 変更内容

### 新規追加ファイル
- `frontend/PeriodTracker.xcodeproj/` - Xcodeプロジェクト
- `frontend/PeriodTracker/PeriodTrackerApp.swift` - アプリエントリーポイント
- `frontend/PeriodTracker/ContentView.swift` - メイン画面
- `frontend/PeriodTracker/Features/Auth/` - 認証機能（LoginView, SignUpView）
- `frontend/PeriodTracker/Features/Calendar/` - カレンダー機能（CalendarView）
- `frontend/PeriodTracker/Features/Home/` - ホーム機能（HomeView, RecordModal）
- `frontend/PeriodTracker/Features/Chat/` - チャット機能（ChatView）
- `frontend/PeriodTracker/Assets.xcassets/` - アセット（アイコン、画像）
- `frontend/PeriodTracker/Resource/mock_record.json` - モックデータ（未実装）
- `frontend/README.md` - フロントエンド開発用README

### 更新ファイル
- `.gitignore` -  Xcode, Swiftに関連した内容を更新

## 技術スタック
- **UIフレームワーク**: SwiftUI
- **言語**: Swift 6.0以上
- **アーキテクチャ**: 機能分割+MVVM（予定）
- **依存関係**: 標準ライブラリのみ（今後追加の可能性もあり）
- **開発環境**: Xcode 16.4以上、iOS 18.0以上

## 実装済み
-  基本的なUI構造（Auth、Calendar、Home、Chat）
-  Xcodeプロジェクト設定
-  アセット管理（Assets.xcassets）
- .gitignoreの更新
- フロントエンド開発用README

## 未実装（今後の実装予定）
-  APIService（バックエンドAPI連携）
-  ViewModel（MVVMアーキテクチャ）
-  データモデル（APIレスポンス用）
-  エラーハンドリング
- unitテスト

## セットアップ方法

### 1. Xcodeプロジェクトを開く
```bash
cd frontend
open PeriodTracker.xcodeproj
```

### 2. ビルド・実行
```bash
# Xcodeで Product → Run を選択
# または ⌘ + R でビルド・実行
```

### 3. 動作確認
- iOSシミュレータが起動
- 基本的なUIが表示される
- タブ切り替えが動作する

## 注意事項
- 現在はUIのみで、実際の機能は未実装
- バックエンドとの連携は今後の実装予定
- Xcode 16.4以上、iOS 18.0以上が必要
- 標準ライブラリのみ使用（外部依存関係なし）