### PR TITLE
feat:APIServiceクラスにpatchメソッドを追加、getメソッドにクエリパラメータ の付与を可能に

### DIFF
--- a/frontend/PeriodTracker/Core/Network/testapiView.swift
+++ b/frontend/PeriodTracker/Core/Network/testapiView.swift
@@ -4,43 +4,183 @@
 //
 //  Created by 藤瀬太翼 on 2025/07/06.
 //
-
 import SwiftUI
+import Foundation
+// DTOファイルを直接import
+// もしmodule importが不要なら下記importは省略可
+// import "../Models/DTO/UserDTO.swift"
+// import "../Models/DTO/PeriodDTO.swift"
+// import "../Models/DTO/ChatDTO.swift"
+// import "../Models/DTO/AuthDTO.swift"
 
-struct testapi: View {
-    @State private var getResult = ""
-    @State private var postResult = ""
+struct TestAPIView: View {
+    @State private var resultText = ""
+    
     var body: some View {
-        VStack {
-            Button("Test get") {
-                let apiService = APIService()
-                apiService.get("http://127.0.0.1:8000/"){(result: Result<User, Error>) in
-                    switch result {
-                    case .success(let data):
-                        getResult = "Get Success: \(data)"
-                    case .failure(let error):
-                        getResult = "Get Failed: \(error)"
+        ScrollView {
+            VStack(spacing: 16) {
+                // /register (POST)
+                Button("Test /register (POST)") {
+                    let apiService = APIService()
+                    let registerData = UserRegisterRequestDTO(email: "test@example.com", password: "password", name: "テストユーザー")
+                    apiService.post("http://127.0.0.1:8000/register", data: registerData) { (result: Result<UserRegisterResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "register: \(data)"
+                        case .failure(let error):
+                            resultText = "register error: \(error.localizedDescription)"
+                        }
                     }
                 }
-            }
-            Button("Test post") {
-                let user = User(id: 1, name: "test")
-                let apiService = APIService()
-                apiService.post("http://127.0.0.1:8000/", data: user){(result: Result<String, Error>) in
-                    switch result {
-                    case .success(let data):
-                        postResult = "Post Success: \(data)"
-                    case .failure(let error):
-                        postResult = "Post Failed: \(error)"
+                // /login (POST)
+                Button("Test /login (POST)") {
+                    let apiService = APIService()
+                    let loginData = UserLoginRequestDTO(email: "test@example.com", hasehed_password: "password")
+                    apiService.post("http://127.0.0.1:8000/login", data: loginData) { (result: Result<UserLoginResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "login: \(data)"
+                        case .failure(let error):
+                            resultText = "login error: \(error.localizedDescription)"
+                        }
                     }
                 }
+                // /google (POST)
+                Button("Test /google (POST)") {
+                    let apiService = APIService()
+                    let googleData = ["id_token_str": "sample_id_token"] // 必要ならDTO化
+                    apiService.post("http://127.0.0.1:8000/google", data: googleData) { (result: Result<UserLoginResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "google: \(data)"
+                        case .failure(let error):
+                            resultText = "google error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /forgot-password (POST)
+                Button("Test /forgot-password (POST)") {
+                    let apiService = APIService()
+                    let forgotData = ForgotPasswordRequestDTO(email: "test@example.com")
+                    apiService.post("http://127.0.0.1:8000/forgot-password", data: forgotData) { (result: Result<ForgotPasswordResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "forgot-password: \(data)"
+                        case .failure(let error):
+                            resultText = "forgot-password error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /reset-password (POST)
+                Button("Test /reset-password (POST)") {
+                    let apiService = APIService()
+                    let resetData = ResetPasswordRequestDTO(token: "sampletoken", password: "newpassword")
+                    apiService.post("http://127.0.0.1:8000/reset-password", data: resetData) { (result: Result<ResetPasswordResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "reset-password: \(data)"
+                        case .failure(let error):
+                            resultText = "reset-password error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /me (GET)
+                Button("Test /me (GET)") {
+                    let apiService = APIService()
+                    apiService.get("http://127.0.0.1:8000/me") { (result: Result<UserProfileResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "me: \(data)"
+                        case .failure(let error):
+                            resultText = "me error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /period (POST)
+                Button("Test /period (POST)") {
+                    let apiService = APIService()
+                    let periodData = PeriodStartRequestDTO(id: 1, startdate: "2025-07-11")
+                    apiService.post("http://127.0.0.1:8000/period", data: periodData) { (result: Result<PeriodStartResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "period post: \(data)"
+                        case .failure(let error):
+                            resultText = "period post error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /period (PATCH)
+                Button("Test /period (PATCH)") {
+                    let apiService = APIService()
+                    let periodUpdate = PeriodEndRequestDTO(id: 1, userid: 1, enddate: "2025-07-17")
+                    apiService.patch("http://127.0.0.1:8000/period/1", data: periodUpdate) { (result: Result<PeriodEndResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "period patch: \(data)"
+                        case .failure(let error):
+                            resultText = "period patch error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /period (GET)
+                Button("Test /period (GET)") {
+                    let apiService = APIService()
+                    apiService.get("http://127.0.0.1:8000/period") { (result: Result<PeriodCalendarResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "period: \(data)"
+                        case .failure(let error):
+                            resultText = "period error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /period (DELETE)
+                Button("Test /period (DELETE)") {
+                    let url = URL(string: "http://127.0.0.1:8000/period/1")!
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "DELETE"
+                    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                        if let error = error {
+                            resultText = "period delete error: \(error.localizedDescription)"
+                        } else {
+                            resultText = "period delete: success"
+                        }
+                    }
+                    task.resume()
+                }
+                // /chat (POST)
+                Button("Test /chat (POST)") {
+                    let apiService = APIService()
+                    let chatData = ChatSendRequestDTO(query: "生理痛がつらいです…", mode: "王子様モード")
+                    apiService.post("http://127.0.0.1:8000/chat", data: chatData) { (result: Result<ChatSendResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "chat post: \(data)"
+                        case .failure(let error):
+                            resultText = "chat post error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                // /chat (GET)
+                Button("Test /chat (GET)") {
+                    let apiService = APIService()
+                    apiService.get("http://127.0.0.1:8000/chat") { (result: Result<ChatHistoryResponseDTO, Error>) in
+                        switch result {
+                        case .success(let data):
+                            resultText = "chat: \(data)"
+                        case .failure(let error):
+                            resultText = "chat error: \(error.localizedDescription)"
+                        }
+                    }
+                }
+                Text(resultText)
+                    .padding()
             }
-            Text(getResult)
-            Text(postResult)
+            .padding()
         }
     }
 }
 
 #Preview {
-    testapi()
+    TestAPIView()
 }

--- a/frontend/PeriodTracker/MockData/Period/start_response.json
+++ b/frontend/PeriodTracker/MockData/Period/start_response.json
@@ -6,5 +6,5 @@
   "prediction_next_date": "2025-08-08",
   "prediction_end_date": "2025-07-17",
   "created_at": "2025-07-11T09:00:00Z",
-  "update_at": "2025-07-11T09:00:00Z"
+  "updated_at": "2025-07-11T09:00:00Z"
 } 

--- a/frontend/test.py
+++ b/frontend/test.py
@@ -1,0 +1,116 @@
+from fastapi import FastAPI, status
+from fastapi.responses import JSONResponse
+import json
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    """APIのルートエンドポイント。"""
+    return {"message": "Welcome to the Period Tracker API!"}
+
+# ユーザー新規登録
+@app.post("/register", status_code=status.HTTP_201_CREATED)
+async def register_user_mock():
+    # MockDataのパス（必要に応じて絶対パスや環境変数で調整）
+    mock_path = "PeriodTracker/MockData/User/register_response.json"
+    # ファイルを開いてJSONを読み込む
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    # そのまま返すえ
+    return JSONResponse(content=mock_data, status_code=status.HTTP_201_CREATED)
+
+# ユーザーログイン (ローカル認証)
+@app.post("/login", status_code=status.HTTP_200_OK)
+async def login_for_access_token_mock():
+    mock_path = "PeriodTracker/MockData/User/login_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# Google認証
+@app.post("/google", status_code=status.HTTP_200_OK)
+async def google_auth_mock():
+    mock_path = "PeriodTracker/MockData/User/login_response.json"  # 必要に応じてgoogle用のmockを作成
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# パスワード再設定要求
+@app.post("/forgot-password", status_code=status.HTTP_200_OK)
+async def forgot_password_mock():
+    mock_path = "PeriodTracker/MockData/Auth/forgot_password_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# パスワード再設定実行
+@app.post("/reset-password", status_code=status.HTTP_200_OK)
+async def reset_password_mock():
+    mock_path = "PeriodTracker/MockData/Auth/reset_password_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# ユーザープロフィール取得
+@app.get("/me", status_code=status.HTTP_200_OK)
+async def read_users_me_mock():
+    mock_path = "PeriodTracker/MockData/User/profile_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+
+# ① 生理開始記録
+@app.post("/period", status_code=status.HTTP_201_CREATED)
+async def create_period_entry_mock():
+    mock_path = "PeriodTracker/MockData/Period/start_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_201_CREATED)
+
+# ② 生理終了記録 / 生理期間更新
+@app.patch("/period/{period_id}", status_code=status.HTTP_200_OK)
+async def update_period_entry_mock(period_id: int):
+    mock_path = "PeriodTracker/MockData/Period/end_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# ③ カレンダー表示＆六ヶ月分の表示
+@app.get("/period", status_code=status.HTTP_200_OK)
+async def read_periods_mock():
+    mock_path = "PeriodTracker/MockData/Period/calendar_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# 特定生理期間の取得
+# @app.get("/period/{period_id}", status_code=status.HTTP_200_OK)
+# async def read_single_period_mock(period_id: int):
+#     mock_path = "Period
+#     with open(mock_path, "r", encoding="utf-8") as f:
+#         mock_data = json.load(f)
+#     # 必要に応じてperiod_idでフィルタリングする処理を追加可能
+#     return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)
+
+# 生理期間の削除
+@app.delete("/period/{period_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_period_entry_mock(period_id: int):
+    # 削除は204 No Contentなのでボディなし
+    return JSONResponse(content=None, status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.post("/chat", status_code=status.HTTP_201_CREATED)
+async def create_chat_entry_mock():
+    mock_path = "PeriodTracker/MockData/Chat/send_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_201_CREATED)
+
+@app.get("/chat", status_code=status.HTTP_200_OK)
+async def read_chat_history_mock():
+    mock_path = "PeriodTracker/MockData/Chat/history_response.json"
+    with open(mock_path, "r", encoding="utf-8") as f:
+        mock_data = json.load(f)
+    return JSONResponse(content=mock_data, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
## 概要
APIServiceクラスの機能拡張およびテスト用API画面・モックデータの修正、FastAPI用モックサーバースクリプトの追加。
これにより、APIのPATCHリクエストやGET時のクエリパラメータ付与が可能となり、フロントエンドからのAPIテストも実行可能。

## 具体的な変更内容
- APIService.swift
PATCHメソッド（patch関数）を新規追加
GETメソッドでクエリパラメータ（queryItems）を付与できるように修正

- testapiView.swift
FastAPIモックサーバー（test.py）のエンドポイント・HTTPメソッドに合わせてテスト用ボタン・リクエスト内容・DTO型を修正
POST/GET/PATCH/DELETEなど正しいHTTPメソッドでAPIを呼び出すように統一

- start_response.json
DTO定義に合わせてモックデータの内容を修正

- test.py
FastAPI用のモックAPIサーバースクリプトを新規追加
フロントエンドからのAPIテスト用に、各種エンドポイントのモックレスポンスを実装