### PR TITLE
feat: パスワードの再設定のMVVMの実装

### DIFF
--- a/frontend/PeriodTracker/Core/Repositories/User/MockUserRepository.swift
+++ b/frontend/PeriodTracker/Core/Repositories/User/MockUserRepository.swift
@@ -26,6 +26,14 @@ final class MockUserRepository: UserRepository {
             try await api.post("http://127.0.0.1:8000/login", data: dto)
         return responseDTO.toDomain()
     }
+
+    // パスワード再設定要求
+    func sendResetPassword(_ dto: ForgotPasswordRequestDTO) async throws -> ForgotPasswordResponseDTO {
+        let responseDTO: ForgotPasswordResponseDTO = 
+            try await api.post("http://127.0.0.1:8000/forgot-password", data: dto)
+        return responseDTO
+    }
+
     func fetchProfile() async throws -> User {
         let responseDTO: UserProfileResponseDTO = 
             try await api.get("http://127.0.0.1:8000/me")

--- a/frontend/PeriodTracker/Core/Repositories/User/NetworkUserRepository.swift
+++ b/frontend/PeriodTracker/Core/Repositories/User/NetworkUserRepository.swift
@@ -39,4 +39,10 @@ final class NetworkUserRepository: UserRepository {
             // 本番環境のAPIのURLに差し替え
         return responseDTO.toDomain()
     }
+    func sendResetPassword(_ dto: ForgotPasswordRequestDTO) async throws -> ForgotPasswordResponseDTO {
+        let responseDTO: ForgotPasswordResponseDTO = 
+            try await api.post("本番環境のAPIのURL", data: dto)
+            // 本番環境のAPIのURLに差し替え
+        return responseDTO
+    }
 }

--- a/frontend/PeriodTracker/Core/Repositories/User/UserRepository.swift
+++ b/frontend/PeriodTracker/Core/Repositories/User/UserRepository.swift
@@ -11,6 +11,8 @@ protocol UserRepository {
     func login(_ request: UserLoginRequestDTO) async throws -> User 
     // ユーザープロフィール取得
     func fetchProfile() async throws -> User 
+    // パスワード再設定要求
+    func sendResetPassword(_ request: ForgotPasswordRequestDTO) async throws -> ForgotPasswordResponseDTO
 }
 
 // _ requestは呼び出し側でラベルを書く必要がない

--- a/frontend/PeriodTracker/Features/Auth/LoginView.swift
+++ b/frontend/PeriodTracker/Features/Auth/LoginView.swift
@@ -28,6 +28,10 @@ struct LoginView: View {
                             .font(.title)
                             .fontWeight(.bold)
                         
+                        Text("ログイン")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        
                         Text("あなたの健康をサポート")
                             .font(.caption)
                             .foregroundColor(.gray)
@@ -40,13 +44,14 @@ struct LoginView: View {
                             .textFieldStyle(RoundedBorderTextFieldStyle())
                             .padding(.horizontal)
                         
-                        Button(action: {
-                            // パスワードリセット処理
-                        }) {
+                        NavigationLink(destination: ResetPasswordView(viewModel: ResetPasswordViewModel(userRepository: MockUserRepository()))) {
                             Text("パスワードをお忘れの方はこちら")
                                 .font(.footnote)
                                 .foregroundColor(.blue)
                         }
+                        .padding(.horizontal)
+
+
                         Button(action: {
                             // LoginViewModel.login()は非同期関数だが、
                             // Buttonのactionは非同期関数ではないため、
@@ -83,6 +88,7 @@ struct LoginView: View {
                         Divider()
                         Text("登録がお済みでない方はこちら")
                             .font(.caption)
+
                         NavigationLink(destination: SignUpView(viewModel: SignUpViewModel(userRepository: MockUserRepository()))) {
                             Text("新規登録")
                                 .frame(maxWidth: .infinity)

--- a/frontend/PeriodTracker/Features/Auth/ResetPasswordView.swift
+++ b/frontend/PeriodTracker/Features/Auth/ResetPasswordView.swift
@@ -1,0 +1,65 @@
+//  ResetPasswordView.swift
+//  PeriodTracker
+//
+//  Created by 藤瀬太翼 on 2025/07/12.
+//
+
+import SwiftUI
+
+struct ResetPasswordView: View {
+    @StateObject var viewModel: ResetPasswordViewModel
+    @Environment(\.dismiss) private var dismiss
+    var body: some View { 
+        ZStack {
+            Color.blue.opacity(0.1)
+                .ignoresSafeArea()
+            VStack(spacing: 16) {
+                Image(systemName: "heart.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 50, height: 50)
+                    .foregroundColor(.blue)
+
+                Text("PeriodCare")
+                    .font(.title)
+                    .foregroundColor(.blue)
+
+                Text("パスワード再設定")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Text("登録したメールアドレスを入力してください")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+
+                TextField("メールアドレス", text: $viewModel.email)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+
+                Button(action: {
+                    Task {
+                        await viewModel.sendResetPassword()
+                        dismiss()
+                    }
+                }) {
+                    Text("パスワード再設定メールを送信")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+            .padding()
+            .frame(width: UIScreen.main.bounds.width * 0.8,
+                   height: UIScreen.main.bounds.height * 0.5)
+            .background(Color.white)
+            .cornerRadius(20)
+            .shadow(radius:10)
+        }
+    }
+}
+#Preview {
+    ResetPasswordView(
+        viewModel: ResetPasswordViewModel(userRepository: MockUserRepository())
+        )
+}

--- a/frontend/PeriodTracker/Features/Auth/ResetPasswordViewModel.swift
+++ b/frontend/PeriodTracker/Features/Auth/ResetPasswordViewModel.swift
@@ -1,0 +1,45 @@
+//  ResetPasswordViewModel.swift
+//  PeriodTracker
+//
+//  Created by 藤瀬太翼 on 2025/07/12.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class ResetPasswordViewModel: ObservableObject {
+    @Published var email: String = ""
+    @Published var error: String? = nil
+
+    private let userRepository: UserRepository
+    init(userRepository: UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    func sendResetPassword() async -> Bool {
+        guard validate() else { return false }
+
+        do {
+            let request = ForgotPasswordRequestDTO(email: email)
+            let response = try await userRepository.sendResetPassword(request)
+            return true
+        } catch {
+            self.error = error.localizedDescription
+            return false
+        }
+    }
+    
+    private func validate() -> Bool {
+        if email.isEmpty {
+            self.error = "メールアドレスを入力してください"
+            return false
+        }
+        if !email.contains("@") {
+            self.error = "有効なメールアドレスを入力してください"
+            return false
+        }
+        self.error = nil
+        return true
+    }
+}

--- a/frontend/PeriodTracker/Features/Auth/SignUpView.swift
+++ b/frontend/PeriodTracker/Features/Auth/SignUpView.swift
@@ -26,6 +26,9 @@ struct SignUpView: View {
                 Text("PeriodCare")
                     .font(.title)
                     .fontWeight(.bold)
+                Text("新規登録")
+                    .font(.title2)
+                    .fontWeight(.bold)
                 
                 Text("あなたの健康をサポート")
                     .font(.caption)


### PR DESCRIPTION
## 概要
パスワード再設定のview, viewmodelの実装
login画面からの遷移の実装
パスワード再設定apiを叩くラッパ関数（repositoryディレクトリ内）の実装